### PR TITLE
Add ssb-pub script. Separate out pub management

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,11 @@
 
 #### Developer Libs/Tools
 * [scuttlebot](https://github.com/ssbc/scuttlebot)
-* [easy-ssb-pub](https://github.com/staltz/easy-ssb-pub)
 * [git-ssb](https://github.com/clehner/git-ssb)
+
+#### Pub Hosting/Management
+* [ssb-pub](https://github.com/ahdinosaur/ssb-pub) - Easy way to setup your own Pub.
+* [easy-ssb-pub](https://github.com/staltz/easy-ssb-pub) - (No longer maintained) Alternative easy setup script.
 
 #### Consumer Apps
 * [Patchwork](https://github.com/ssbc/patchwork) `(social)`


### PR DESCRIPTION
- Add link to ahdinosaur/ssb-pub which is a working script to easily setup a SSB pub server
- Add deprecation message to staltz/easy-ssb-pub
- Split pub hosting/management into its own section.